### PR TITLE
Add intelhex to python deps, for esptool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ platformio==6.1.18
 nanopb==0.4.9.1
 grpcio-tools==1.73.1
 adafruit-nrfutil==0.5.3.post16
+intelhex==2.3.0
 meshtastic==2.6.4


### PR DESCRIPTION
Fix for https://github.com/meshtastic/firmware/pull/7523

Add intelhex to python deps, for esptool (managed by PlatformIO)