### PR TITLE
Update Python to 3.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "grpcio-tools"
+        # Ignore updates until 2.x is released.
+        versions: ["<2"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Base image
-# !! espressif32 platform does not yet support python 3.14
-FROM python:3.13-trixie AS base
+FROM python:3.14-trixie AS base
 ENV PIP_ROOT_USER_ACTION=ignore
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
DO NOT MERGE until pioarduino >3.3.6 (based on platformio `6.1.19`) is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s underlying runtime environment to the latest supported Python release.
  * Refined automated maintenance settings to improve update stability while preparing for a future major release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->