### PR TITLE
Revert grpcio-tools to 1.78.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 platformio==6.1.19
 nanopb==0.4.9.1
-grpcio-tools==1.78.1
+grpcio-tools==1.78.0
 adafruit-nrfutil==0.5.3.post16
 meshtastic==2.7.7


### PR DESCRIPTION
grpcio-tools 1.78.1 has been yanked
https://pypi.org/project/grpcio-tools/1.78.1/