### PR TITLE
Build (but do not consume) containers for `develop`

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -20,6 +20,10 @@ on:
         description: PlatformIO platform to target
         required: true
         type: string
+      meshtastic_branch:
+        description: Meshtastic branch to fetch dependencies from
+        required: true
+        type: string
     outputs:
       digest:
         description: Digest of built image
@@ -74,7 +78,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            GHA-master-${{ inputs.pio_platform }}-${{ steps.sanitize_platform.outputs.cleaned_platform }}
+            GHA-${{ inputs.meshtastic_branch }}-${{ inputs.pio_platform }}-${{ steps.sanitize_platform.outputs.cleaned_platform }}
           flavor: latest=false
 
       - name: Docker build and push
@@ -88,3 +92,4 @@ jobs:
           platforms: ${{ inputs.platform }}
           build-args: |
             PIO_PLATFORM=${{ inputs.pio_platform }}
+            DEPS_FROM_REF=${{ inputs.meshtastic_branch }}

--- a/.github/workflows/docker_manifest.yml
+++ b/.github/workflows/docker_manifest.yml
@@ -6,6 +6,10 @@ on:
         description: PlatformIO platform to target
         required: true
         type: string
+      meshtastic_branch:
+        description: Meshtastic branch to fetch dependencies from
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -25,6 +29,7 @@ jobs:
       platform: linux/amd64
       runs-on: ubuntu-24.04
       push: true
+      meshtastic_branch: ${{ inputs.meshtastic_branch }}
     secrets: inherit
 
   docker-arm64:
@@ -34,6 +39,7 @@ jobs:
       platform: linux/arm64
       runs-on: ubuntu-24.04-arm
       push: true
+      meshtastic_branch: ${{ inputs.meshtastic_branch }}
     secrets: inherit
 
   docker-manifest:
@@ -57,7 +63,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            master-${{ inputs.pio_platform }}
+            ${{ inputs.meshtastic_branch }}-${{ inputs.pio_platform }}
           flavor: latest=false
 
       - name: Create Docker manifest

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -30,4 +30,5 @@ jobs:
       platform: linux/amd64
       runs-on: ubuntu-24.04
       push: false
+      meshtastic_branch: develop
     secrets: inherit

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -31,7 +31,11 @@ jobs:
           - rp2040
           - rp2350
           - stm32
+        mt_branch:
+          - master
+          - develop
     uses: ./.github/workflows/docker_manifest.yml
     with:
       pio_platform: ${{ matrix.pio_platform }}
+      meshtastic_branch: ${{ matrix.mt_branch }}
     secrets: inherit


### PR DESCRIPTION
This pull request updates the Docker build and manifest GitHub Actions workflows to support specifying the Meshtastic branch used for fetching dependencies. This change allows builds and images to be differentiated by branch, improving traceability and flexibility for multi-branch development and testing.

**Workflow Input and Tagging Updates**

* Added a new `meshtastic_branch` input to both `.github/workflows/docker_build.yml` and `.github/workflows/docker_manifest.yml`, making it required for builds and manifests. [[1]](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bR23-R26) [[2]](diffhunk://#diff-d97a43eb3612dfe13e9edf726ffc59bab3636951744f6b68cdb7294c7a6cf395R9-R12)
* Updated Docker image tags in both workflows to include the `meshtastic_branch`, ensuring images are uniquely identified by branch. [[1]](diffhunk://#diff-7a41826c9e419fe38a2da72e1c873ad8ed7eff0ef7cf097c7a99905a261e481bL77-R81) [[2]](diffhunk://#diff-d97a43eb3612dfe13e9edf726ffc59bab3636951744f6b68cdb7294c7a6cf395L60-R66)
* Passed the `meshtastic_branch` as a build argument (`DEPS_FROM_REF`) to Docker builds, so dependencies are fetched from the correct branch.

**Matrix and Default Branch Handling**

* Modified `.github/workflows/on_push.yml` to matrix over both `pio_platform` and `mt_branch` (Meshtastic branch), passing the branch to the manifest workflow.
* Set a default `meshtastic_branch` of `develop` for PR builds in `.github/workflows/on_pr.yml`.

**Job Configuration Consistency**

* Ensured the `meshtastic_branch` input is passed to both `docker-amd64` and `docker-arm64` jobs in the manifest workflow for consistent multi-architecture builds. [[1]](diffhunk://#diff-d97a43eb3612dfe13e9edf726ffc59bab3636951744f6b68cdb7294c7a6cf395R32) [[2]](diffhunk://#diff-d97a43eb3612dfe13e9edf726ffc59bab3636951744f6b68cdb7294c7a6cf395R42)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker builds can now target a specified Meshtastic branch.
  * Release workflows now produce Docker images for both the `master` and `develop` branches.
  * Pull request builds target the `develop` branch by default.
  * Docker image tags now identify the branch used for each build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->