### PR TITLE
Use containers from develop branch. Bump python-meshtastic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           --env MT_VERBOSE \
           --env PIO_TOKEN \
           -v $GITHUB_WORKSPACE:/workspace \
-          ghcr.io/meshtastic/gh-action-firmware:master-${{ inputs.pio_platform }}
+          ghcr.io/meshtastic/gh-action-firmware:develop-${{ inputs.pio_platform }}
       shell: bash
       env:
         PLATFORMIO_BUILD_DIR: /workspace/.pio/build

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ platformio==6.1.19
 nanopb==0.4.9.1
 grpcio-tools==1.82.1
 adafruit-nrfutil==0.5.3.post16
-meshtastic==2.7.10
+meshtastic==2.7.11


### PR DESCRIPTION
Use containers built from `develop` branch at runtime.
Bump python meshtastic package.

Hopefully this doesn't break stuff!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the firmware build process to use the development platform image.
  * Updated the Meshtastic package to version 2.7.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->