### PR TITLE
Add pioarduino hack to fix esptool MATCH

### DIFF
--- a/bin/pio_load_and_dedupe.sh
+++ b/bin/pio_load_and_dedupe.sh
@@ -27,6 +27,48 @@ echo "$to_build" | while read -r env; do
 done
 echo "All packages loaded successfully."
 
+
+# PIOARDUINO HACK:
+# https://github.com/pioarduino/platform-espressif32/blob/55.03.39/builder/penv_setup.py#L557-L578
+# esp32: bake esptool as an *editable* install of the tool-esptoolpy package.
+#
+# The espressif32 platform expects `import esptool` to resolve from inside the
+# tool-esptoolpy package dir. But esp-coredump (pulled in by the platform's
+# Python-deps step) depends on esptool, so a *regular* copy lands in the penv's
+# site-packages first and shadows it. The platform then fails its own check
+#     dirname(esptool.__file__) startswith <.../packages/tool-esptoolpy>
+# on every build and re-runs `uv pip install --force-reinstall -e ...`, which
+# re-fetches from PyPI and occasionally exceeds its 60s timeout.
+#
+# Fixing it here (in the penv, which is core-level state that survives `pio run`
+# — unlike the platform dir, which is re-extracted and would revert edits) makes
+# that check pass, so the platform skips the reinstall entirely at build time.
+if [[ "$PLATFORM_SRC" == esp32* ]]; then
+    penv="$PLATFORMIO_CORE_DIR/penv"
+    esptool_pkg="$PLATFORMIO_CORE_DIR/packages/tool-esptoolpy"
+    if [[ -x "$penv/bin/uv" && -d "$esptool_pkg" ]]; then
+        echo "Baking editable esptool from $esptool_pkg"
+        export UV_CACHE_DIR="$PLATFORMIO_CORE_DIR/.cache/uv"
+        # Drop the regular (esp-coredump-pulled) esptool, then install the tool
+        # package editable so it resolves from inside tool-esptoolpy.
+        "$penv/bin/uv" pip uninstall --python "$penv/bin/python" esptool 2>/dev/null || true
+        "$penv/bin/uv" pip install --python "$penv/bin/python" -e "$esptool_pkg"
+        # Precompile so the platform's 5s `import esptool` check is never the bottleneck.
+        "$penv/bin/python" -m compileall -q "$penv" "$esptool_pkg" || true
+        # Assert the platform's MATCH condition now holds; fail the build loudly if not.
+        "$penv/bin/python" - "$esptool_pkg" <<'PY'
+import esptool, os, sys
+expected = os.path.normcase(os.path.realpath(sys.argv[1]))
+actual = os.path.normcase(os.path.realpath(os.path.dirname(esptool.__file__)))
+if not actual.startswith(expected):
+    sys.exit(f"ERROR: esptool did not install editable under {expected} (got {actual})")
+print(f"esptool editable OK: {actual}")
+PY
+    else
+        echo "WARNING: penv uv or tool-esptoolpy not found; skipping esptool bake." >&2
+    fi
+fi
+
 if [[ "$PLATFORM_SRC" != esp32* ]]; then
     # Replace duplicate files in the core directory with hard links
     echo "Deduplicating $PLATFORMIO_CORE_DIR"


### PR DESCRIPTION
## Fix intermittent esptool `TimeoutExpired` on esp32 firmware builds

### Summary
esp32 firmware builds intermittently fail during package configuration with:

```
Error in package configuration: TimeoutExpired: Command '['/pio/core/penv/bin/uv', 'pip', 'install', '--quiet', '--force-reinstall', '--python=/pio/core/penv/bin/python', '-e', '/pio/core/packages/tool-esptoolpy']' timed out after 60 seconds
```

This pre-stages esptool correctly at **container-build** time so the espressif32 platform stops re-installing it (and occasionally timing out) at **firmware-build** time.

### Root cause
The [espressif32 platform](https://github.com/pioarduino/platform-espressif32/blob/55.03.39/builder/penv_setup.py#L557-L578) expects `import esptool` to resolve from *inside* the `tool-esptoolpy` package dir, and guards its install with a check equivalent to:

```
dirname(esptool.__file__).startswith(<.../packages/tool-esptoolpy>)
```

But `esp-coredump` — installed by the platform's Python-deps step, which runs **before** the esptool step — declares `Requires-Dist: esptool` (unpinned). So a **regular** `esptool` lands in the penv's `site-packages` first (`/pio/core/penv/lib/python3.13/site-packages/esptool`) and shadows the tool package. The guard therefore returns MISMATCH on **every** build, and the platform re-runs:

```
uv pip install --quiet --force-reinstall -e /pio/core/packages/tool-esptoolpy
```

`--force-reinstall` implies uv's `--refresh`, so this re-fetches esptool + its build backend from PyPI every time — and that network step occasionally blows past the platform's hard-coded 60s timeout.

### Fix
After `pio pkg install`, for `esp32*` platforms, bake esptool as an **editable** install of `tool-esptoolpy` into the penv:

1. Uninstall the regular (esp-coredump-pulled) `esptool`.
2. `uv pip install -e <tool-esptoolpy>` so `import esptool` resolves from inside the package dir.
3. `compileall` the penv so the platform's 5s `import esptool` check is never the bottleneck.
4. Assert the platform's MATCH condition now holds — the container build **fails loudly** if it doesn't (e.g. a future platform change), so we can't ship a silently-broken image.

The platform's own (unmodified) check then returns MATCH at firmware-build time and skips the reinstall entirely.

### Why fix it here, in the penv?
The check inspects the **penv** (`/pio/core/penv`), which is core-level state that persists across `pio run`. Earlier attempts didn't hold:

- **`UV_OFFLINE=1` at runtime** — too blunt; broke other steps that legitimately fetch uv deps at build time.
- **Patching `penv_setup.py` to drop `--force-reinstall`** — `penv_setup.py` lives inside the platform *package*, which PlatformIO re-extracts on `pio run`, reverting the edit before it takes effect.

Fixing the penv means we satisfy the platform's own check rather than fighting its code — nothing to override.

### Scope / notes
- **esp32 only.** Non-esp32 platforms are untouched (no penv / `tool-esptoolpy`).
- Pins esptool to `tool-esptoolpy`'s version (5.3.0), overriding the unpinned version `esp-coredump` would pull. This is the platform's intended behavior, not a side effect.
- No functional change to the built firmware — only which esptool the penv resolves.

### Verification
Build fails loudly if the bake doesn't produce an editable install. To confirm on a built image:

```bash
docker run --rm --entrypoint bash ghcr.io/meshtastic/gh-action-firmware:<branch>-esp32 \
  -c '/pio/core/penv/bin/python -c "import esptool,os;print(os.path.dirname(esptool.__file__))"'
```

Expected: a path under `/pio/core/packages/tool-esptoolpy` (not `…/penv/lib/python3.13/site-packages/esptool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)