### PR TITLE
Only copy cache for ESP32 (not the entire core)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -49,8 +49,18 @@ LABEL org.opencontainers.image.authors="vidplace7"
 # the dedup in the final image. Stream through tar over a bind mount instead: tar
 # preserves hardlinks (and symlinks), and the bind mount means no intermediate
 # tarball is ever written to a layer.
-RUN --mount=type=bind,from=pio_deps,source=/pio,target=/mnt/pio \
-    mkdir -p /pio && tar -C /mnt/pio -cf - . | tar -C /pio -xf -
+RUN --mount=type=bind,from=pio_deps,source=/pio/workspace,target=/mnt/pio-workspace \
+    mkdir -p /pio/workspace && tar -C /mnt/pio-workspace -cf - . | tar -C /pio/workspace -xf -
+# For esp32 the packages/penv are provided elsewhere, so only the uv/esptool cache
+# under /pio/core/.cache is needed (see UV_CACHE_DIR in bin/pio_load_and_dedupe.sh).
+# For every other platform, copy the whole /pio/core. Bind-mount all of /pio/core
+# so the mount source always exists regardless of which branch runs.
+ARG PIO_PLATFORM
+RUN --mount=type=bind,from=pio_deps,source=/pio/core,target=/mnt/pio-core \
+    case "$PIO_PLATFORM" in \
+      esp32*) mkdir -p /pio/core/.cache && tar -C /mnt/pio-core/.cache -cf - . | tar -C /pio/core/.cache -xf - ;; \
+      *) mkdir -p /pio/core && tar -C /mnt/pio-core -cf - . | tar -C /pio/core -xf - ;; \
+    esac
 
 WORKDIR /workspace
 RUN git config --global --add safe.directory /workspace


### PR DESCRIPTION
This pull request updates the way PlatformIO dependencies and caches are copied into the container, adding support for platform-specific handling (especially for esp32). The changes ensure that only the necessary cache is copied for esp32, while other platforms continue to copy the entire core directory.

**PlatformIO dependency and cache handling:**

* The bind mount and copy operation for `/pio/workspace` is updated to use the subdirectory `/pio/workspace` instead of the root `/pio` directory, improving organization and avoiding unnecessary files.
* Introduced a new `PIO_PLATFORM` build argument and conditional logic to copy only the `/pio/core/.cache` directory for esp32 platforms, and the entire `/pio/core` directory for all other platforms, optimizing image size and build performance.
* Updated the bind mount source for `/pio/core` to always exist, ensuring consistent behavior across all branches and platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds by preserving hardlinked PlatformIO artifacts.
  * Ensured platform-specific cache files are transferred correctly, helping maintain reliable build behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->