### PR TITLE
Pull the build image explicitly and log which one ran

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,27 @@ runs:
   steps:
     - id: build_meshtastic
       run: |
+        set -euo pipefail
+
+        # `docker run` alone defaults to --pull=missing, so a runner that already has
+        # this (mutable) tag cached keeps using it indefinitely and a republished image
+        # never reaches the build. Pull explicitly: it is a cheap manifest check when the
+        # local copy is already current, and correct when it is not. Tolerate a failed
+        # pull so a registry blip falls back to the cached image rather than failing the
+        # build outright.
+        if ! docker pull --quiet "$MT_IMAGE"; then
+          echo "::warning::docker pull failed for $MT_IMAGE - falling back to the locally cached image"
+        fi
+
+        # Record which image actually ran. Without this the image vintage is invisible in
+        # the logs, so a container-side regression cannot be told apart from a code-side
+        # one when triaging a failed build.
+        echo "::group::Container image"
+        docker image inspect "$MT_IMAGE" \
+          --format 'image:   {{index .RepoDigests 0}}{{"\n"}}created: {{.Created}}{{"\n"}}rev:     {{index .Config.Labels "org.opencontainers.image.revision"}}' \
+          || echo "could not inspect $MT_IMAGE"
+        echo "::endgroup::"
+
         docker run --rm \
           --env GITHUB_ACTIONS \
           --env XDG_CACHE_HOME \
@@ -47,9 +68,10 @@ runs:
           --env MT_VERBOSE \
           --env PIO_TOKEN \
           -v $GITHUB_WORKSPACE:/workspace \
-          ghcr.io/meshtastic/gh-action-firmware:${{ inputs.meshtastic_branch }}-${{ inputs.pio_platform }}
+          "$MT_IMAGE"
       shell: bash
       env:
+        MT_IMAGE: ghcr.io/meshtastic/gh-action-firmware:${{ inputs.meshtastic_branch }}-${{ inputs.pio_platform }}
         PLATFORMIO_BUILD_DIR: /workspace/.pio/build
         MT_ENV: ${{ inputs.pio_env }}
         MT_PLATFORM: ${{ inputs.pio_platform }}


### PR DESCRIPTION
## Problem

`action.yml` invokes the builder with a bare `docker run`, which defaults to **`--pull=missing`**. A runner that already has the mutable `:<branch>-<platform>` tag cached keeps using it indefinitely — so **a republished image never reaches the build**, and there is no record of which image actually ran.

This is not theoretical. On 2026-07-25:

- the `develop-esp32s3` manifest was republished at **06:53:57Z**
- the [07:37Z nightly](https://github.com/meshtastic/firmware/actions/runs/30149645315) lost 23 esp32/esp32s3 legs
- all 23 job logs show container output **0.4–1.8 s** after `docker run`, with no `Unable to find image`, no `Pulling from`, and no `Digest:` line

For comparison, the same pipeline logs a full `Unable to find image / Pulling from / Digest:` sequence taking ~2m19s when a real pull happens. So that republish provably never reached the runners, and the nightly ran a cached image of unrecorded vintage.

That cost real triage time: it is currently impossible to tell from a failed build whether the container or the code regressed.

## Change

- **`docker pull` explicitly** before running. Cheap manifest check when the local copy is already current; correct when it is not. A failed pull emits a `::warning::` and falls back to the cached image rather than failing the build on a registry blip.
- **Log the resolved digest, created timestamp and source revision** in a collapsed group, so image vintage is visible in every build log.
- Hoist the image reference into an `MT_IMAGE` env var so pull, inspect and run cannot drift apart.

Verified: YAML parses, the embedded script passes `bash -n`, and the `docker image inspect --format` string was exercised against a real image (missing labels render empty rather than erroring, and the `|| echo` guards an image with no `RepoDigests`).

## Context for the esp32 timeout — findings that affect #52 and #53

While tracking down the nightly failures I found things worth flagging here, @vidplace7:

**1. Both mitigations were removed, by accident.** `31e7fdf` added `UV_OFFLINE=1`; `98a7697` replaced it with `bin/patch-esp32_uv_reinstall.sh` (and removed `UV_OFFLINE`). Then #50 (`keep-the-links`), whose branch was cut **2h39m before `98a7697` landed**, deleted `bin/patch-esp32_uv_reinstall.sh` and its Containerfile hook:

```
$ git log --diff-filter=D -- bin/patch-esp32_uv_reinstall.sh
498c931 Fancy bind mount (#50)
```

`main` has no branch protection and no rulesets (`branches/main/protection` → 404, `rulesets` → `[]`), so nothing forced that branch to absorb `main` first. A ruleset with **strict (branch-up-to-date) status checks** would have prevented it.

**2. #52 as written is currently a no-op for esp32, for two independent reasons.**

- It bakes into `/pio/core/penv`, but #53's `esp32*)` branch copies only `/pio/core/.cache` into the final image. I confirmed this from the published image config: `develop-esp32` (created 06:15:40Z) has one `/pio/core` layer containing only `pio/core/.cache/downloads/*` — no `platforms`, `packages` or `penv`. So anything written to the penv at image-build time is discarded. **This is the same clobber shape as #50 → `98a7697`.**
- Its bake step fails at image-build time anyway:
  ```
  Baking editable esptool from /pio/core/packages/tool-esptoolpy
  error: /pio/core/packages/tool-esptoolpy does not appear to be a Python project,
         as neither `pyproject.toml` nor `setup.py` are present in the directory
  ```
  The `-d` guard passes (the dir exists, `tool-esptoolpy@5.3.0 has been installed!` appears twice), but at that point it is not an installable project. Curiously it *is* one by the time `pio run` does penv setup — the runtime `-e` install times out rather than erroring. Worth understanding before #52 lands; I could not determine it without building the container.

**3. The patch target in #52's description points at dead code.** `--force-reinstall` appears **twice** in `penv_setup.py@55.03.39` (lines 585 and 811). The reachable one is **811**, via `platform.py:827 → setup_penv_minimal → _setup_python_environment_core(env=None) → line 675`. Line 585 sits behind an `env is not None` SCons branch that `configure_default_packages` never reaches. The deleted `patch-esp32_uv_reinstall.sh` used a global `sed …/g`, so it was correct despite citing L584-588.

**4. Reverting #53 is not cheap.** Measured, compressed, within-platform: `develop-esp32` amd64 went 2,449,559,615 → 1,039,902,850 B (−57.5%); `nrf52840` control unchanged (+0.0017%). Restoring the full core adds back ~1.41 GB per esp32 image per arch. An additive copy of just `penv` + `packages/tool-esptoolpy` would be far cheaper — if the "not a Python project" issue above can be resolved.

**5. `esp32c6 × master` has been failing on a permanent 404** since at least 00:32Z:
```
PackageException: Got the unrecognized status code '404' when downloaded
https://github.com/vidplace7/platform-espressif32/releases/download/meshtastic-esp32c6/framework-arduinoespressif32-all-release_v5.1-124d64e.zip
```
That makes every `Build Release` run report `failure` even when the develop manifests publish fine (00:32Z and 05:54Z both did), so a genuine image regression is indistinguishable from the standing one. Worth fixing just to restore the signal — and in the meantime, gate on the per-leg `docker-platforms (esp32|esp32s3, develop) / docker-manifest` jobs rather than the run conclusion.

**Interim fix:** meshtastic/firmware#11217 patches the timeout from the firmware side. Since `entrypoint.sh` runs `/workspace/bin/build-esp32.sh` and the workspace is bind-mounted, that takes effect on the next job against any image vintage — which is what makes it viable while the container-side fix is worked out.
