### PR TITLE
Replace grpcio-tools version pin with range from nanopb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 platformio==6.1.19
 nanopb==0.4.9.1
-grpcio-tools==1.82.1
 adafruit-nrfutil==0.5.3.post16
 meshtastic==2.7.11
+# Match grpcio-tools version pinning from nanopb (where it's consumed)
+# but cap it below 2.x so a major release can't break the build unannounced.
+grpcio-tools>=1.43.0,<2


### PR DESCRIPTION
grpcio-tools is pinned to >=1.43 in nanopb (where it's consumed), so match this behavior.

This was previously causing grpcio-tools to be downloaded upon every firmware build when the grpcio-tools version is not latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `grpcio-tools` version requirement to support compatible releases while avoiding breaking major-version upgrades.
  * Clarified dependency compatibility requirements in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->