### PR TITLE
ESP32: Preload pioarduino scons

### DIFF
--- a/bin/pio_load_and_dedupe.sh
+++ b/bin/pio_load_and_dedupe.sh
@@ -13,6 +13,12 @@ to_build=$(
 
 echo "Gathering environments for platform: $PLATFORM_SRC"
 
+TOOL_FLAGS="--tool platformio/tool-cppcheck --tool platformio/tool-mklittlefs"
+# Preload additional tools on ESP32 platforms
+if [[ "$PLATFORM_SRC" == esp32* ]]; then
+    TOOL_FLAGS="$TOOL_FLAGS --tool https://github.com/pioarduino/scons/releases/download/4.8.1/scons-local-4.8.1.tar.gz"
+fi
+
 echo "$to_build" | while read -r env; do
     echo "################################################"
     echo "▶️ Loading pkgs for env: $env"
@@ -21,9 +27,7 @@ echo "$to_build" | while read -r env; do
     pio pkg install --environment "$env"
     # Install additional tools
     # `--no-save` prevents this from modifying platformio.ini
-    pio pkg install --environment "$env" --no-save \
-        --tool platformio/tool-cppcheck \
-        --tool platformio/tool-mklittlefs
+    pio pkg install --environment "$env" --no-save $TOOL_FLAGS
 done
 echo "All packages loaded successfully."
 


### PR DESCRIPTION
Preload `tool-scons` from pioarduino. Currently this is being downloaded upon every build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PlatformIO tool installation across supported platform configurations.
  * Ensured required analysis and filesystem tools are installed consistently.
  * Preserved existing package deduplication and environment detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->